### PR TITLE
Corrected "documentation" url

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -10,7 +10,7 @@
   </maintainer>
   <urls>
     <url desc="Main Extension Page">https://github.com/CiviCooP/org.civicoop.emailapi</url>
-    <url desc="documentation">https://github.com/CiviCooP/org.civicoop.emailapi/README.md</url>
+    <url desc="documentation">https://github.com/CiviCooP/org.civicoop.emailapi/blob/master/README.md</url>
     <url desc="Support">http://civicoop.org</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>


### PR DESCRIPTION
Old value was pointing to a 404 error on github.